### PR TITLE
Add Swift Mark snippet

### DIFF
--- a/Mark.swift
+++ b/Mark.swift
@@ -1,0 +1,1 @@
+// MARK: - <#Section#>

--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,7 @@ swift-dispatchasync                  GCD dispatch_async snippet for Swift
 swift-dispatchmain                   GCD dispatch_async on main queue snippet for Swift
 swift-documentdirectory              Document directory path snippet for Swift
 swift-mail                           MFMailComposeViewController snippet for Swift
+swift-mark                           Mark snippet for Swift
 swift-message                        MFMessageComposeViewController snippet for Swift
 swift-nslocalizedstring              NSLocalizedString function snippet for Swift
 swift-singleton-new                  Singleton pattern for Swift 1.2 using class constant

--- a/plist/swift-mark.codesnippet
+++ b/plist/swift-mark.codesnippet
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDECodeSnippetCompletionPrefix</key>
+	<string>swift-mark</string>
+	<key>IDECodeSnippetCompletionScopes</key>
+	<array>
+		<string>TopLevel</string>
+		<string>ClassImplementation</string>
+	</array>
+	<key>IDECodeSnippetContents</key>
+	<string>// MARK: - &lt;#Section#&gt;</string>
+	<key>IDECodeSnippetIdentifier</key>
+	<string>7329708D-DA17-4129-A8F9-A780DFA5FAE1</string>
+	<key>IDECodeSnippetLanguage</key>
+	<string>Xcode.SourceCodeLanguage.Swift</string>
+	<key>IDECodeSnippetSummary</key>
+	<string>Divider label for separating code into sections</string>
+	<key>IDECodeSnippetTitle</key>
+	<string>Swift Mark:</string>
+	<key>IDECodeSnippetUserSnippet</key>
+	<true/>
+	<key>IDECodeSnippetVersion</key>
+	<integer>2</integer>
+</dict>
+</plist>


### PR DESCRIPTION
This pr adds the Swift `// MARK: -` snippet, which is useful for separating code into sections. Note this snippet includes the `-` as part of the snippet.  The `-` will add a divider line in the Xcode jump bar.
