### PR TITLE
Typo from old use of deprecated NSIndexPath, add annotations

### DIFF
--- a/swift-uicollectionviewdatasource.codesnippet
+++ b/swift-uicollectionviewdatasource.codesnippet
@@ -14,18 +14,20 @@
         func numberOfSections(in collectionView: UICollectionView) -&gt; Int {
             return &lt;#numberOfSections#&gt;
         }
-
+	
         func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -&gt; Int {
+	    // TODO:- Required Method
             return &lt;#numberOfItems#&gt;
         }
 
-        func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -&gt; UICollectionViewCell {
+	func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -&gt; UICollectionViewCell {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: &lt;#identifier#&gt;, for: indexPath)
             configureCell(cell: cell, forItemAt: indexPath)
+	    // TODO:- Required Method
             return cell
         }
 
-        func configureCell(cell: UICollectionViewCell, forItemAt indexPath: NSIndexPath) {
+        func configureCell(cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
 
         }
 


### PR DESCRIPTION
I think it's a good idea to mark which ones that are required, that way we can just delete the methods we don't need without referring to it in the documentation.