### PR TITLE
Use shared instead of sharedInstance

### DIFF
--- a/swift-singleton.codesnippet
+++ b/swift-singleton.codesnippet
@@ -9,7 +9,7 @@
 		<string>ClassImplementation</string>
 	</array>
 	<key>IDECodeSnippetContents</key>
-	<string>static let sharedInstance : &lt;#SingletonClass#&gt; = &lt;#SingletonClass#&gt;()</string>
+	<string>static let shared : &lt;#SingletonClass#&gt; = &lt;#SingletonClass#&gt;()</string>
 	<key>IDECodeSnippetIdentifier</key>
 	<string>D0964789-8FAA-4A94-8E5B-D5178137F102</string>
 	<key>IDECodeSnippetLanguage</key>


### PR DESCRIPTION
Apple shanged all their API to used `shared` instead of `sharedInstance`
for all their variables that points to the signelton instance of an
class. This commit will ensure that the snippets for signelton classes
are doing the same.