### PR TITLE
swift 4.2 update.

### DIFF
--- a/swift-weak.codesnippet
+++ b/swift-weak.codesnippet
@@ -10,7 +10,7 @@
 	</array>
 	<key>IDECodeSnippetContents</key>
 	<string>[weak self] in
-            guard let `self` = self else { return }</string>
+            guard let self = self else { return }</string>
 	<key>IDECodeSnippetIdentifier</key>
 	<string>B5FFB5B9-1B62-49B5-B1E1-0749BBE07D42</string>
 	<key>IDECodeSnippetLanguage</key>


### PR DESCRIPTION
Since guard let 'self' results in a compiler bug, this new update is better and compatible with Swift 4.2+